### PR TITLE
fix: Cast GitHub provider id to string

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -10,7 +10,7 @@ export default function GitHub(options) {
     profileUrl: "https://api.github.com/user",
     profile(profile) {
       return {
-        id: profile.id,
+        id: profile.id.toString(),
         name: profile.name || profile.login,
         email: profile.email,
         image: profile.avatar_url,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Reasoning 💡

When using:
- `Providers.GitHub` - from `next-auth@^3.27.0`
- `PrismaAdapter` - from `@next-auth/prisma-adapter@^0.4.4-canary.81`

The callback route fails with this error:

```
Argument providerAccountId: Got invalid value 2637602 on prisma.findUniqueAccount. Provided Int, expected String.
```

This occurs because the account id returned from [GitHub's API](https://api.github.com/user) is an integer, not a string.  [docs](https://docs.github.com/en/rest/reference/users)
![Screen Shot 2021-06-27 at 12 43 00 AM](https://user-images.githubusercontent.com/2637602/123536670-a25db280-d6e0-11eb-9620-e3a7d57fcf25.png)



<details>
<summary>Full stack trace</summary>

<code>
[next-auth][error][prisma__get_user_by_provider_account_id_error]
https://next-auth.js.org/errors#prisma__get_user_by_provider_account_id_error PrismaClientValidationError:
Invalid `prisma.account.findUnique()` invocation:

{
  where: {
    providerId_providerAccountId: {
      providerId: 'github',
      providerAccountId: 2637602
                         ~~~~~~~
    }
  },
  select: {
    user: true
  }
}


Argument providerAccountId: Got invalid value 2637602 on prisma.findUniqueAccount. Provided Int, expected String.


    at Document.validate (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:32546:19)
    at NewPrismaClient._executeRequest (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34652:17)
    at consumer (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34597:23)
    at /Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34599:47
    at AsyncResource.runInAsyncScope (node:async_hooks:199:9)
    at NewPrismaClient._request (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34599:25)
    at Object.then (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34707:39)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  clientVersion: '2.25.0'
}
[next-auth][error][oauth_callback_handler_error]
https://next-auth.js.org/errors#oauth_callback_handler_error Error:
Invalid `prisma.account.findUnique()` invocation:

{
  where: {
    providerId_providerAccountId: {
      providerId: 'github',
      providerAccountId: 2637602
                         ~~~~~~~
    }
  },
  select: {
    user: true
  }
}

Argument providerAccountId: Got invalid value 2637602 on prisma.findUniqueAccount. Provided Int, expected String.


    at Document.validate (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:32546:19)
    at NewPrismaClient._executeRequest (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34652:17)
    at consumer (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34597:23)
    at /Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34599:47
    at AsyncResource.runInAsyncScope (node:async_hooks:199:9)
    at NewPrismaClient._request (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34599:25)
    at Object.then (/Users/brian/staffbar/staffbar-mono/node_modules/@prisma/client/runtime/index.js:34707:39)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  name: 'GetUserByProviderAccountIdError'
}
</code>
</details>

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

~- [ ] Documentation~
- [x] Tests (Tested locally but didn't really see any test coverage that exists for this code 🤷 )
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
